### PR TITLE
use user key instead of id

### DIFF
--- a/content/src/policies/__id/put.rego
+++ b/content/src/policies/__id/put.rego
@@ -12,5 +12,5 @@ allowed {
 }
 
 allowed {
-	input.user.id == input.resource.id
+	input.user.key == input.resource.id
 }

--- a/content/src/policies/__id/put.rego
+++ b/content/src/policies/__id/put.rego
@@ -14,3 +14,7 @@ allowed {
 allowed {
 	input.user.key == input.resource.id
 }
+
+allowed {
+	input.user.id == input.resource.id
+}


### PR DESCRIPTION
https://github.com/aserto-demo/peoplefinder - is using dir v1 users, so it can evaluate `user.id`
https://github.com/aserto-demo/peoplefinder-acmecorp/pull/29 - will be using the new directory with no ids, so it needs to evaluate `user.key`